### PR TITLE
Patch to fix icons in Moodle 1.9 version of course menu

### DIFF
--- a/course_menu/block_course_menu.php
+++ b/course_menu/block_course_menu.php
@@ -589,7 +589,13 @@ class block_course_menu extends block_base
         foreach ($sections as $k => $section) {
     		foreach ($section['resources'] as $l => $resource) {
 	    		$iconClass = $resource['icon'];
-	    		$iconClass = substr($iconClass, strrpos($iconClass, '/') + 1);
+	    		$iconClass = explode('/', $iconClass);
+	    		$len = count($iconClass);
+	    		if ($len >= 2) {
+	    			$iconClass = $iconClass[$len-2].'-'.$iconClass[$len-1];
+	    		} else {
+	    			$iconClass = $iconClass[0]; // Unlikely to happen, but just in case ...
+	    		}
 	    		$iconClass = substr($iconClass, 0, strrpos($iconClass, '.'));
 	    		$iconClass = preg_replace('/[^a-zA-Z0-9]+/', '-', $iconClass);
 	    		$iconClass = "icon".$iconClass;


### PR DESCRIPTION
The course menu displays identical icons for all activities in a section.

This is due to all the activity / resource entries having CSS class 'iconicon', which is generated from 'icon' + filename of icon file (which in the case of activities is always 'icon.gif' - e.g. [url]/mod/questionnaire/icon.gif, [url]/mod/forum/icon.gif).

This patch uses the last 2 elements from the path and joins them together with a '-' (e.g. 'iconquestionnaire-icon',  'iconforum-icon', or, for an image resource, 'iconf-image'). This means that the CSS class names are always unique.
