### PR TITLE
Update block_course_menu.php

### DIFF
--- a/course_menu/block_course_menu.php
+++ b/course_menu/block_course_menu.php
@@ -341,7 +341,7 @@ class block_course_menu extends block_base
         $output .= '</div>';
 
         $this->contentgenerated = true;
-        $this->content->text = $output;
+        $this->content->text = '<style>.block_navigation .block_tree .tree_item.hasicon{white-space:normal;}</style>'.$output;
 
         return $this->content;
     }


### PR DESCRIPTION
Unfortunately the navigation style is theme dependent, so no matter how I change the style in the css of the course menu, the theme overrides it and the white-space:nowrap, will prevent lines from wrapping should the theme decide so. To enforce wrapping consistently over themes, the change needs to be added into the course menu generation file. I narrowed it down to this one change.
